### PR TITLE
Rewrite tsvtools section

### DIFF
--- a/notebooks/label_extraction.ipynb
+++ b/notebooks/label_extraction.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26ee4f09",
+   "id": "55898452",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "94bca8f2",
+   "id": "c371d8cf",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -35,7 +35,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8545662d",
+   "id": "cd87d16d",
    "metadata": {},
    "source": [
     "## Before starting\n",
@@ -51,7 +51,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a05fbe6b",
+   "id": "fa9451cc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -63,7 +63,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d7f66bbd",
+   "id": "086c0e37",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -76,7 +76,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6055244d",
+   "id": "86bd9d9d",
    "metadata": {},
    "source": [
     "## Get metadata from a BIDS hierarchy with `clinica iotools`\n",
@@ -102,7 +102,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23455159",
+   "id": "7ed9ea0b",
    "metadata": {},
    "source": [
     "We are going to run some experiments on the ADNI and OASIS datasets, \n",
@@ -115,7 +115,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eb598537",
+   "id": "87a21f8e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -126,7 +126,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a67b4c4a",
+   "id": "d5496277",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -137,7 +137,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "54c13d54",
+   "id": "9d56efb8",
    "metadata": {},
    "source": [
     "### Check missing modalities for each subject\n",
@@ -163,7 +163,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0349e501",
+   "id": "188c0782",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -176,7 +176,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35e110f2",
+   "id": "554562ef",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -187,7 +187,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0698d946",
+   "id": "2580defe",
    "metadata": {},
    "source": [
     "The output of this command, `missing_mods/`, is a folder with a series of\n",
@@ -197,58 +197,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9c10c484",
+   "id": "286791fb",
    "metadata": {},
    "source": [
     "## Prepare metadata with `clinicadl tsvtools` \n",
     "\n",
-    "```{note}\n",
-    "If you want to do the next experiment in proper conditions, you will have to\n",
-    "download the full data from [ADNI](https://adni.loni.usc.edu/) or\n",
-    "[OASIS](https://oasis-brains.org/). Indeed, it is not possible to separate a\n",
-    "set of 4 images without data leakage. You will need also to process the data,\n",
-    "as shown in the [previous notebook]((./preprocessing.ipynb)), in a BIDS and a\n",
-    "CAPS specification.\n",
-    "```\n",
+    "In this section we will work on a subset of 100 sessions of the OASIS dataset\n",
+    "(and a subset of 100 sessions of the ADNI dataset) and you only need the list\n",
+    "of the sessions, for now. \n",
     "\n",
-    "In this section we will work on a subset of 100 subjects of the OASIS dataset\n",
-    "(and a subset of 100 subjects of the ADNI dataset) and you only need the list\n",
-    "of subjects, for now. You can find this list of participants that have passed\n",
-    "the quality check in the data folder (`oasis_after_qc.tsv` and \n",
-    "`adni_after_qc.tsv`).\n",
+    "The whole preprocessing process has been run for you on these datasets. The\n",
+    "results of the [quality check procedure](./preprocessing.ipynb#quality-check-of-your-preprocessed-data) have been used\n",
+    "to filter sessions. `data_oasis/oasis_after_qc.tsv` and `data_adni/adni_after_qc.tsv`\n",
+    "store the list of the sessions that have been accepted for each dataset.\n",
     "\n",
-    "If you are not able to run the whole preprocessing process on the full\n",
-    "dataset, you can uncomment the next cell and download the necessary resources\n",
-    "(the `merged.tsv` file  and the `missing_mods` directory)."
+    "You can run the next cell to download the necessary resources\n",
+    "(`merged.tsv` and `oasis_after_qc.tsv` - or `adni_after_qc.tsv` - files,\n",
+    "as well as the `missing_mods` directory)."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "541bb500",
+   "id": "ace882d0",
    "metadata": {},
    "outputs": [],
    "source": [
     "#for OASIS-1 dataset\n",
     "!curl -k https://aramislab.paris.inria.fr/clinicadl/files/handbook_2023/data_oasis/iotools_output.tar.gz -o iotools_output.tar.gz\n",
-    "!tar xf iotools_output.tar.gz"
+    "!tar xf iotools_output.tar.gz\n",
+    "!curl https://raw.githubusercontent.com/aramis-lab/clinicadl_handbook/main/data/oasis_after_qc.tsv  -O data_oasis/oasis_after_qc.tsv"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1150db5d",
+   "id": "a55b0bf6",
    "metadata": {},
    "outputs": [],
    "source": [
     "#for the ADNI dataset\n",
     "!curl -k https://aramislab.paris.inria.fr/clinicadl/files/handbook_2023/data_adni/iotools_output.tar.gz -o iotools_output.tar.gz\n",
-    "!tar xf iotools_output.tar.gz"
+    "!tar xf iotools_output.tar.gz\n",
+    "!curl https://raw.githubusercontent.com/aramis-lab/clinicadl_handbook/main/data/adni_after_qc.tsv  -O data_adni/adni_after_qc.tsv"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "60359937",
+   "id": "55c1b5b6",
    "metadata": {},
    "source": [
     "### Get the labels\n",
@@ -277,7 +273,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6e2be4f8",
+   "id": "aa5fd47b",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -290,18 +286,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cfb433a0",
+   "id": "72ca116c",
    "metadata": {
     "lines_to_next_cell": 0
    },
    "outputs": [],
    "source": [
-    "!clinicadl tsvtools get-labels data_oasis/BIDS_example --merged_tsv data_oasis/merged.tsv --missing_mods data_oasis/missing_mods --restriction_tsv data/oasis_after_qc.tsv"
+    "!clinicadl tsvtools get-labels data_oasis/BIDS_example data_oasis --merged_tsv data_oasis/merged.tsv --missing_mods data_oasis/missing_mods --restriction_tsv data_oasis/oasis_after_qc.tsv"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "45cef011",
+   "id": "d540ed84",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -318,18 +314,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0a116c0c",
+   "id": "db7594ba",
    "metadata": {
     "lines_to_next_cell": 0
    },
    "outputs": [],
    "source": [
-    "!clinicadl tsvtools get-labels data_adni/BIDS_example --merged_tsv data_adni/merged.tsv --missing_mods data_adni/missing_mods --restriction_tsv data/adni_after_qc.tsv -d CN -d Dementia -d MCI"
+    "!clinicadl tsvtools get-labels data_adni/BIDS_example data_adni --merged_tsv data_adni/merged.tsv --missing_mods data_adni/missing_mods --restriction_tsv data_adni/adni_after_qc.tsv -d CN -d Dementia -d MCI"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "b7c7b06e",
+   "id": "1573ddc9",
    "metadata": {},
    "source": [
     "This tool writes a unique TSV file containing the labels asked by the user.\n",
@@ -337,10 +333,10 @@
     "\n",
     "<div class=\"alert alert-block alert-info\">\n",
     "<b>Restriction path:</b><p>\n",
-    "    At the end of the command line a restriction was given to extract the\n",
-    "    labels only from sessions in <code>data/oasis_after_qc.tsv</code>. This tsv\n",
-    "    file corresponds to the output of the <a\n",
-    "    href=\"./preprocessing.ipynb\">quality check procedure</a> that was manually\n",
+    "    At the end of the command line, a restriction was given to extract the\n",
+    "    labels only from sessions in <code>oasis_after_qc.tsv</code>. This tsv\n",
+    "    file corresponds to the output of the  <a\n",
+    "    href=\"./preprocessing.html#quality-check-of-your-preprocessed-data\">quality check procedure</a> that was manually\n",
     "    cut to only keep the sessions passing the quality check. It depends on the\n",
     "    preprocessing: here it concerns a run of <code>t1-linear</code>.</p>\n",
     "</div>"
@@ -348,7 +344,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bec62af5",
+   "id": "8feb18c4",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -368,8 +364,8 @@
     "clinicadl tsvtools analysis <merged_tsv> <data_tsv> <results_path>\n",
     "```\n",
     "where:\n",
-    "- `merged_tsv` is the output file of the `clinica iotools merge-tsv`command.\n",
-    "- `data_tsv` is the output file of `clinicadl tsvtool getlabels|split|kfold`).\n",
+    "- `merged_tsv` is the output file of the `clinica iotools merge-tsv` command.\n",
+    "- `data_tsv` is the output file of `clinicadl tsvtool getlabels|split|kfold`.\n",
     "- `results_path` is the path to the tsv file that will be written (filename included).\n",
     "\n",
     "\n",
@@ -381,7 +377,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e30a1468",
+   "id": "863242e9",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -394,7 +390,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3e6cb97f",
+   "id": "f924b792",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -405,7 +401,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "baddf909",
+   "id": "fe6fdd01",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -438,7 +434,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f1b22eff",
+   "id": "bf10e5bc",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -450,7 +446,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fcfa623c",
+   "id": "ba0cfca8",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -461,7 +457,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c7e86586",
+   "id": "1a00fc46",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -477,7 +473,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "866f0ef2",
+   "id": "b9c67f48",
    "metadata": {},
    "source": [
     "There is no significant bias on age anymore, but do you notice any other\n",
@@ -498,7 +494,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1bbafae0",
+   "id": "74632cbe",
    "metadata": {},
    "source": [
     "### Get the progression of the Alzheimer's disease\n",
@@ -524,7 +520,7 @@
     "  clinicadl tsvtools get-progression [OPTIONS] DATA_TSV\n",
     "``` \n",
     "with :\n",
-    " - `<data_tsv>` (str) is the TSV file containing the data (output of clinicadl\n",
+    " - `DATA_TSV` (str) is the TSV file containing the data (output of clinicadl\n",
     " tsvtools get-labels|split|kfold).\n",
     " - `--time_horizon` (int) can be added: It is the time horizon in months that\n",
     " is used to assess the stability of the MCI subjects. Default value: 36.\n",
@@ -537,7 +533,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "01a23ad0",
+   "id": "2f8befb2",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -548,7 +544,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5ba375aa",
+   "id": "c6caefdf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -558,7 +554,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25da815c",
+   "id": "3d67dbd9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -570,7 +566,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "005091a6",
+   "id": "f027ec15",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -631,7 +627,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "223dd4a7",
+   "id": "824d618a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -641,7 +637,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9ad29555",
+   "id": "9edf9741",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -653,7 +649,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "04474eac",
+   "id": "dd1dde5b",
    "metadata": {},
    "source": [
     "The differences between the populations of the train + validation and test \n",
@@ -664,7 +660,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "715b9774",
+   "id": "e76f48e0",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -676,7 +672,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66320b1c",
+   "id": "a7fbcffe",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -688,7 +684,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "de07bc54",
+   "id": "a5bc4e9f",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -702,14 +698,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a3921a68",
+   "id": "f9668260",
    "metadata": {
     "lines_to_next_cell": 0
    },
    "source": [
-    "If you are not satisfied with these populations, you can relaunch the test or\n",
+    "If you are not satisfied with these populations, you can relaunch the `clinicadl tsvtools split` command and\n",
     "change the parameters used to evaluate the difference between the\n",
-    "distributions: `p_val_threshold` and `t_val_threshold`.\n",
+    "distributions: `p_age_threshold` and `p_sex_threshold`.\n",
     "\n",
     "<div class=\"alert alert-block alert-info\">\n",
     "<b>Unique test set:</b>\n",
@@ -724,7 +720,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "da60ccdb",
+   "id": "5b45893c",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -758,7 +754,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "98be1125",
+   "id": "2bb51a9e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -768,7 +764,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f90b39a0",
+   "id": "9500cd52",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -780,7 +776,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "80cd1fc6",
+   "id": "1d385b60",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -809,7 +805,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f87e8de6",
+   "id": "6c98b0d6",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -899,7 +895,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "044e417a",
+   "id": "4f658289",
    "metadata": {},
    "source": [
     "If no Error was raised then none of the three conditions was broken. It is now\n",
@@ -920,7 +916,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e82be001",
+   "id": "d3e3a434",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -932,7 +928,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "da9c80d7",
+   "id": "bf610483",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/notebooks/label_extraction.ipynb
+++ b/notebooks/label_extraction.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "84ddfe02",
+   "id": "bb2afa6e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a67df716",
+   "id": "082b19b3",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -35,7 +35,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fa868aab",
+   "id": "a1299e95",
    "metadata": {},
    "source": [
     "## Before starting\n",
@@ -51,7 +51,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2fa37543",
+   "id": "a77c183f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -63,7 +63,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ffe6de08",
+   "id": "b012265c",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -76,7 +76,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "692744c4",
+   "id": "cd2290b6",
    "metadata": {},
    "source": [
     "## Get metadata from a BIDS hierarchy with `clinica iotools`\n",
@@ -102,7 +102,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8bb3e28e",
+   "id": "56426a0d",
    "metadata": {},
    "source": [
     "We are going to run some experiments on the ADNI and OASIS datasets, \n",
@@ -115,7 +115,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40e42256",
+   "id": "671d02c7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -126,7 +126,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b692a11c",
+   "id": "b0b3141b",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -137,7 +137,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "04ad72b1",
+   "id": "55c45d60",
    "metadata": {},
    "source": [
     "### Check missing modalities for each subject\n",
@@ -163,7 +163,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5a6b3850",
+   "id": "3f7c2bc4",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -176,7 +176,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "82fa6daa",
+   "id": "77dea0ec",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -187,7 +187,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8365cd51",
+   "id": "51ffdf7d",
    "metadata": {},
    "source": [
     "The output of this command, `missing_mods/`, is a folder with a series of\n",
@@ -197,58 +197,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cb826fa8",
+   "id": "7258e5e2",
    "metadata": {},
    "source": [
     "## Prepare metadata with `clinicadl tsvtools` \n",
     "\n",
-    "```{info}\n",
-    "If you want to do the next experiment in proper conditions, you will have to\n",
-    "download the full data from [ADNI](https://adni.loni.usc.edu/) or\n",
-    "[OASIS](https://oasis-brains.org/). Indeed, it is not possible to separate a\n",
-    "set of 4 images without data leakage. You will need also to process the data,\n",
-    "as shown in the [previous notebook]((./preprocessing.ipynb)), in a BIDS and a\n",
-    "CAPS specification.\n",
-    "```\n",
+    "In this section we will work on a subset of 100 sessions of the OASIS dataset\n",
+    "(and a subset of 100 sessions of the ADNI dataset) and you only need the list\n",
+    "of the sessions, for now. \n",
     "\n",
-    "In this section we will work on a subset of 100 subjects of the OASIS dataset\n",
-    "(and a subset of 100 subjects of the ADNI dataset) and you only need the list\n",
-    "of subjects, for now. You can find this list of participants that have passed\n",
-    "the quality check in the data folder (`oasis_after_qc.tsv` and \n",
-    "`adni_after_qc.tsv`).\n",
+    "The whole preprocessing process has been run for you on these datasets. The\n",
+    "results of the [quality check procedure](./preprocessing.ipynb#quality-check-of-your-preprocessed-data) have been used\n",
+    "to filter sessions. `data_oasis/oasis_after_qc.tsv` and `data_adni/adni_after_qc.tsv`\n",
+    "store the list of the sessions that have been accepted for each dataset.\n",
     "\n",
-    "If you are not able to run the whole preprocessing process on the full\n",
-    "dataset, you can uncomment the next cell and download the necessary resources\n",
-    "(the `merged.tsv` file  and the `missing_mods` directory)."
+    "You can run the next cell to download the necessary resources\n",
+    "(`merged.tsv` and `oasis_after_qc.tsv` - or `adni_after_qc.tsv` - files,\n",
+    "as well as the `missing_mods` directory)."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "abb83d46",
+   "id": "843d1edf",
    "metadata": {},
    "outputs": [],
    "source": [
     "#for OASIS-1 dataset\n",
     "!curl -k https://aramislab.paris.inria.fr/clinicadl/files/handbook_2023/data_oasis/iotools_output.tar.gz -o iotools_output.tar.gz\n",
-    "!tar xf iotools_output.tar.gz"
+    "!tar xf iotools_output.tar.gz\n",
+    "!curl https://raw.githubusercontent.com/aramis-lab/clinicadl_handbook/main/data/oasis_after_qc.tsv  -O data_oasis/oasis_after_qc.tsv"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "75f8a168",
+   "id": "cbc72a3e",
    "metadata": {},
    "outputs": [],
    "source": [
     "#for the ADNI dataset\n",
     "!curl -k https://aramislab.paris.inria.fr/clinicadl/files/handbook_2023/data_adni/iotools_output.tar.gz -o iotools_output.tar.gz\n",
-    "!tar xf iotools_output.tar.gz"
+    "!tar xf iotools_output.tar.gz\n",
+    "!curl https://raw.githubusercontent.com/aramis-lab/clinicadl_handbook/main/data/adni_after_qc.tsv  -O data_adni/adni_after_qc.tsv"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "b41a1b18",
+   "id": "6ed9fae9",
    "metadata": {},
    "source": [
     "### Get the labels\n",
@@ -277,7 +273,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "528b0b84",
+   "id": "39808564",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -290,18 +286,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e62d333b",
+   "id": "f5e4719c",
    "metadata": {
     "lines_to_next_cell": 0
    },
    "outputs": [],
    "source": [
-    "!clinicadl tsvtools get-labels data_oasis/BIDS_example --merged_tsv data_oasis/merged.tsv --missing_mods data_oasis/missing_mods --restriction_tsv data/oasis_after_qc.tsv"
+    "!clinicadl tsvtools get-labels data_oasis/BIDS_example data_oasis --merged_tsv data_oasis/merged.tsv --missing_mods data_oasis/missing_mods --restriction_tsv data_oasis/oasis_after_qc.tsv"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "90f0b995",
+   "id": "bb2f9705",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -318,18 +314,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d6b25c51",
+   "id": "98bcc7b7",
    "metadata": {
     "lines_to_next_cell": 0
    },
    "outputs": [],
    "source": [
-    "!clinicadl tsvtools get-labels data_adni/BIDS_example --merged_tsv data_adni/merged.tsv --missing_mods data_adni/missing_mods --restriction_tsv data/adni_after_qc.tsv -d CN -d Dementia -d MCI"
+    "!clinicadl tsvtools get-labels data_adni/BIDS_example data_adni --merged_tsv data_adni/merged.tsv --missing_mods data_adni/missing_mods --restriction_tsv data_adni/adni_after_qc.tsv -d CN -d Dementia -d MCI"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "94bbd47f",
+   "id": "f060bea2",
    "metadata": {},
    "source": [
     "This tool writes a unique TSV file containing the labels asked by the user.\n",
@@ -337,10 +333,10 @@
     "\n",
     "<div class=\"alert alert-block alert-info\">\n",
     "<b>Restriction path:</b><p>\n",
-    "    At the end of the command line a restriction was given to extract the\n",
-    "    labels only from sessions in <code>data/oasis_after_qc.tsv</code>. This tsv\n",
-    "    file corresponds to the output of the <a\n",
-    "    href=\"./preprocessing.ipynb\">quality check procedure</a> that was manually\n",
+    "    At the end of the command line, a restriction was given to extract the\n",
+    "    labels only from sessions in <code>oasis_after_qc.tsv</code>. This tsv\n",
+    "    file corresponds to the output of the  <a\n",
+    "    href=\"./preprocessing.html#quality-check-of-your-preprocessed-data\">quality check procedure</a> that was manually\n",
     "    cut to only keep the sessions passing the quality check. It depends on the\n",
     "    preprocessing: here it concerns a run of <code>t1-linear</code>.</p>\n",
     "</div>"
@@ -348,7 +344,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c53b3781",
+   "id": "6b342d92",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -368,8 +364,8 @@
     "clinicadl tsvtools analysis <merged_tsv> <data_tsv> <results_path>\n",
     "```\n",
     "where:\n",
-    "- `merged_tsv` is the output file of the `clinica iotools merge-tsv`command.\n",
-    "- `data_tsv` is the output file of `clinicadl tsvtool getlabels|split|kfold`).\n",
+    "- `merged_tsv` is the output file of the `clinica iotools merge-tsv` command.\n",
+    "- `data_tsv` is the output file of `clinicadl tsvtool getlabels|split|kfold`.\n",
     "- `results_path` is the path to the tsv file that will be written (filename included).\n",
     "\n",
     "\n",
@@ -381,7 +377,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f026520d",
+   "id": "18db1cce",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -394,7 +390,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6095c777",
+   "id": "6249dc6d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -405,7 +401,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3445491d",
+   "id": "ee7c97e4",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -438,7 +434,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5b460880",
+   "id": "0445e123",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -450,7 +446,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "733fac6f",
+   "id": "3fc27546",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -461,7 +457,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b5af97d1",
+   "id": "026cd0ed",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -477,7 +473,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46084bbc",
+   "id": "ef8ffc00",
    "metadata": {},
    "source": [
     "There is no significant bias on age anymore, but do you notice any other\n",
@@ -498,7 +494,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "350cd672",
+   "id": "16f238ea",
    "metadata": {},
    "source": [
     "### Get the progression of the Alzheimer's disease\n",
@@ -524,7 +520,7 @@
     "  clinicadl tsvtools get-progression [OPTIONS] DATA_TSV\n",
     "``` \n",
     "with :\n",
-    " - `<data_tsv>` (str) is the TSV file containing the data (output of clinicadl\n",
+    " - `DATA_TSV` (str) is the TSV file containing the data (output of clinicadl\n",
     " tsvtools get-labels|split|kfold).\n",
     " - `--time_horizon` (int) can be added: It is the time horizon in months that\n",
     " is used to assess the stability of the MCI subjects. Default value: 36.\n",
@@ -537,7 +533,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "698c452b",
+   "id": "edcf9ce5",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -548,7 +544,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c0404039",
+   "id": "a29fefff",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -558,7 +554,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5be0dec9",
+   "id": "d8cad3e0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -570,7 +566,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32315241",
+   "id": "59777ad3",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -631,7 +627,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c7c8e5bc",
+   "id": "d3ec3501",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -641,7 +637,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "696a22cf",
+   "id": "7bb9b893",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -653,7 +649,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "acc60d80",
+   "id": "3e947c0f",
    "metadata": {},
    "source": [
     "The differences between the populations of the train + validation and test \n",
@@ -664,7 +660,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d5040c95",
+   "id": "34fb4c01",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -676,7 +672,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3e32d163",
+   "id": "28651808",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -688,7 +684,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "990cd60d",
+   "id": "f612df90",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -702,14 +698,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eb796492",
+   "id": "2978a343",
    "metadata": {
     "lines_to_next_cell": 0
    },
    "source": [
-    "If you are not satisfied with these populations, you can relaunch the test or\n",
+    "If you are not satisfied with these populations, you can relaunch the `clinicadl tsvtools split` command and\n",
     "change the parameters used to evaluate the difference between the\n",
-    "distributions: `p_val_threshold` and `t_val_threshold`.\n",
+    "distributions: `p_age_threshold` and `p_sex_threshold`.\n",
     "\n",
     "<div class=\"alert alert-block alert-info\">\n",
     "<b>Unique test set:</b>\n",
@@ -724,7 +720,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "86bd1e74",
+   "id": "14f1eb9f",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -758,7 +754,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "471dee94",
+   "id": "9917feb5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -768,7 +764,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3bfdbc9d",
+   "id": "f5f81232",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -780,7 +776,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "563d7b44",
+   "id": "9d29452d",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -809,7 +805,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "85b7deae",
+   "id": "942a3041",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -899,7 +895,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6eac69d7",
+   "id": "3562ee97",
    "metadata": {},
    "source": [
     "If no Error was raised then none of the three conditions was broken. It is now\n",
@@ -920,7 +916,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6ac02602",
+   "id": "185b369d",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -932,7 +928,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15bc93b1",
+   "id": "e109ec4a",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/notebooks/label_extraction.ipynb
+++ b/notebooks/label_extraction.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55898452",
+   "id": "84ddfe02",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c371d8cf",
+   "id": "a67df716",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -35,7 +35,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cd87d16d",
+   "id": "fa868aab",
    "metadata": {},
    "source": [
     "## Before starting\n",
@@ -51,7 +51,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fa9451cc",
+   "id": "2fa37543",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -63,7 +63,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "086c0e37",
+   "id": "ffe6de08",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -76,7 +76,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "86bd9d9d",
+   "id": "692744c4",
    "metadata": {},
    "source": [
     "## Get metadata from a BIDS hierarchy with `clinica iotools`\n",
@@ -102,7 +102,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7ed9ea0b",
+   "id": "8bb3e28e",
    "metadata": {},
    "source": [
     "We are going to run some experiments on the ADNI and OASIS datasets, \n",
@@ -115,7 +115,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "87a21f8e",
+   "id": "40e42256",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -126,7 +126,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d5496277",
+   "id": "b692a11c",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -137,7 +137,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9d56efb8",
+   "id": "04ad72b1",
    "metadata": {},
    "source": [
     "### Check missing modalities for each subject\n",
@@ -163,7 +163,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "188c0782",
+   "id": "5a6b3850",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -176,7 +176,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "554562ef",
+   "id": "82fa6daa",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -187,7 +187,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2580defe",
+   "id": "8365cd51",
    "metadata": {},
    "source": [
     "The output of this command, `missing_mods/`, is a folder with a series of\n",
@@ -197,54 +197,58 @@
   },
   {
    "cell_type": "markdown",
-   "id": "286791fb",
+   "id": "cb826fa8",
    "metadata": {},
    "source": [
     "## Prepare metadata with `clinicadl tsvtools` \n",
     "\n",
-    "In this section we will work on a subset of 100 sessions of the OASIS dataset\n",
-    "(and a subset of 100 sessions of the ADNI dataset) and you only need the list\n",
-    "of the sessions, for now. \n",
+    "```{info}\n",
+    "If you want to do the next experiment in proper conditions, you will have to\n",
+    "download the full data from [ADNI](https://adni.loni.usc.edu/) or\n",
+    "[OASIS](https://oasis-brains.org/). Indeed, it is not possible to separate a\n",
+    "set of 4 images without data leakage. You will need also to process the data,\n",
+    "as shown in the [previous notebook]((./preprocessing.ipynb)), in a BIDS and a\n",
+    "CAPS specification.\n",
+    "```\n",
     "\n",
-    "The whole preprocessing process has been run for you on these datasets. The\n",
-    "results of the [quality check procedure](./preprocessing.ipynb#quality-check-of-your-preprocessed-data) have been used\n",
-    "to filter sessions. `data_oasis/oasis_after_qc.tsv` and `data_adni/adni_after_qc.tsv`\n",
-    "store the list of the sessions that have been accepted for each dataset.\n",
+    "In this section we will work on a subset of 100 subjects of the OASIS dataset\n",
+    "(and a subset of 100 subjects of the ADNI dataset) and you only need the list\n",
+    "of subjects, for now. You can find this list of participants that have passed\n",
+    "the quality check in the data folder (`oasis_after_qc.tsv` and \n",
+    "`adni_after_qc.tsv`).\n",
     "\n",
-    "You can run the next cell to download the necessary resources\n",
-    "(`merged.tsv` and `oasis_after_qc.tsv` - or `adni_after_qc.tsv` - files,\n",
-    "as well as the `missing_mods` directory)."
+    "If you are not able to run the whole preprocessing process on the full\n",
+    "dataset, you can uncomment the next cell and download the necessary resources\n",
+    "(the `merged.tsv` file  and the `missing_mods` directory)."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ace882d0",
+   "id": "abb83d46",
    "metadata": {},
    "outputs": [],
    "source": [
     "#for OASIS-1 dataset\n",
     "!curl -k https://aramislab.paris.inria.fr/clinicadl/files/handbook_2023/data_oasis/iotools_output.tar.gz -o iotools_output.tar.gz\n",
-    "!tar xf iotools_output.tar.gz\n",
-    "!curl https://raw.githubusercontent.com/aramis-lab/clinicadl_handbook/main/data/oasis_after_qc.tsv  -O data_oasis/oasis_after_qc.tsv"
+    "!tar xf iotools_output.tar.gz"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a55b0bf6",
+   "id": "75f8a168",
    "metadata": {},
    "outputs": [],
    "source": [
     "#for the ADNI dataset\n",
     "!curl -k https://aramislab.paris.inria.fr/clinicadl/files/handbook_2023/data_adni/iotools_output.tar.gz -o iotools_output.tar.gz\n",
-    "!tar xf iotools_output.tar.gz\n",
-    "!curl https://raw.githubusercontent.com/aramis-lab/clinicadl_handbook/main/data/adni_after_qc.tsv  -O data_adni/adni_after_qc.tsv"
+    "!tar xf iotools_output.tar.gz"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "55c1b5b6",
+   "id": "b41a1b18",
    "metadata": {},
    "source": [
     "### Get the labels\n",
@@ -273,7 +277,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aa5fd47b",
+   "id": "528b0b84",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -286,18 +290,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72ca116c",
+   "id": "e62d333b",
    "metadata": {
     "lines_to_next_cell": 0
    },
    "outputs": [],
    "source": [
-    "!clinicadl tsvtools get-labels data_oasis/BIDS_example data_oasis --merged_tsv data_oasis/merged.tsv --missing_mods data_oasis/missing_mods --restriction_tsv data_oasis/oasis_after_qc.tsv"
+    "!clinicadl tsvtools get-labels data_oasis/BIDS_example --merged_tsv data_oasis/merged.tsv --missing_mods data_oasis/missing_mods --restriction_tsv data/oasis_after_qc.tsv"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "d540ed84",
+   "id": "90f0b995",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -314,18 +318,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "db7594ba",
+   "id": "d6b25c51",
    "metadata": {
     "lines_to_next_cell": 0
    },
    "outputs": [],
    "source": [
-    "!clinicadl tsvtools get-labels data_adni/BIDS_example data_adni --merged_tsv data_adni/merged.tsv --missing_mods data_adni/missing_mods --restriction_tsv data_adni/adni_after_qc.tsv -d CN -d Dementia -d MCI"
+    "!clinicadl tsvtools get-labels data_adni/BIDS_example --merged_tsv data_adni/merged.tsv --missing_mods data_adni/missing_mods --restriction_tsv data/adni_after_qc.tsv -d CN -d Dementia -d MCI"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "1573ddc9",
+   "id": "94bbd47f",
    "metadata": {},
    "source": [
     "This tool writes a unique TSV file containing the labels asked by the user.\n",
@@ -333,10 +337,10 @@
     "\n",
     "<div class=\"alert alert-block alert-info\">\n",
     "<b>Restriction path:</b><p>\n",
-    "    At the end of the command line, a restriction was given to extract the\n",
-    "    labels only from sessions in <code>oasis_after_qc.tsv</code>. This tsv\n",
-    "    file corresponds to the output of the  <a\n",
-    "    href=\"./preprocessing.html#quality-check-of-your-preprocessed-data\">quality check procedure</a> that was manually\n",
+    "    At the end of the command line a restriction was given to extract the\n",
+    "    labels only from sessions in <code>data/oasis_after_qc.tsv</code>. This tsv\n",
+    "    file corresponds to the output of the <a\n",
+    "    href=\"./preprocessing.ipynb\">quality check procedure</a> that was manually\n",
     "    cut to only keep the sessions passing the quality check. It depends on the\n",
     "    preprocessing: here it concerns a run of <code>t1-linear</code>.</p>\n",
     "</div>"
@@ -344,7 +348,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8feb18c4",
+   "id": "c53b3781",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -364,8 +368,8 @@
     "clinicadl tsvtools analysis <merged_tsv> <data_tsv> <results_path>\n",
     "```\n",
     "where:\n",
-    "- `merged_tsv` is the output file of the `clinica iotools merge-tsv` command.\n",
-    "- `data_tsv` is the output file of `clinicadl tsvtool getlabels|split|kfold`.\n",
+    "- `merged_tsv` is the output file of the `clinica iotools merge-tsv`command.\n",
+    "- `data_tsv` is the output file of `clinicadl tsvtool getlabels|split|kfold`).\n",
     "- `results_path` is the path to the tsv file that will be written (filename included).\n",
     "\n",
     "\n",
@@ -377,7 +381,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "863242e9",
+   "id": "f026520d",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -390,7 +394,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f924b792",
+   "id": "6095c777",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -401,7 +405,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fe6fdd01",
+   "id": "3445491d",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -434,7 +438,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bf10e5bc",
+   "id": "5b460880",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -446,7 +450,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ba0cfca8",
+   "id": "733fac6f",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -457,7 +461,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1a00fc46",
+   "id": "b5af97d1",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -473,7 +477,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b9c67f48",
+   "id": "46084bbc",
    "metadata": {},
    "source": [
     "There is no significant bias on age anymore, but do you notice any other\n",
@@ -494,7 +498,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "74632cbe",
+   "id": "350cd672",
    "metadata": {},
    "source": [
     "### Get the progression of the Alzheimer's disease\n",
@@ -520,7 +524,7 @@
     "  clinicadl tsvtools get-progression [OPTIONS] DATA_TSV\n",
     "``` \n",
     "with :\n",
-    " - `DATA_TSV` (str) is the TSV file containing the data (output of clinicadl\n",
+    " - `<data_tsv>` (str) is the TSV file containing the data (output of clinicadl\n",
     " tsvtools get-labels|split|kfold).\n",
     " - `--time_horizon` (int) can be added: It is the time horizon in months that\n",
     " is used to assess the stability of the MCI subjects. Default value: 36.\n",
@@ -533,7 +537,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2f8befb2",
+   "id": "698c452b",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -544,7 +548,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c6caefdf",
+   "id": "c0404039",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -554,7 +558,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3d67dbd9",
+   "id": "5be0dec9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -566,7 +570,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f027ec15",
+   "id": "32315241",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -627,7 +631,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "824d618a",
+   "id": "c7c8e5bc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -637,7 +641,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9edf9741",
+   "id": "696a22cf",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -649,7 +653,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dd1dde5b",
+   "id": "acc60d80",
    "metadata": {},
    "source": [
     "The differences between the populations of the train + validation and test \n",
@@ -660,7 +664,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e76f48e0",
+   "id": "d5040c95",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -672,7 +676,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a7fbcffe",
+   "id": "3e32d163",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -684,7 +688,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a5bc4e9f",
+   "id": "990cd60d",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -698,14 +702,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f9668260",
+   "id": "eb796492",
    "metadata": {
     "lines_to_next_cell": 0
    },
    "source": [
-    "If you are not satisfied with these populations, you can relaunch the `clinicadl tsvtools split` command and\n",
+    "If you are not satisfied with these populations, you can relaunch the test or\n",
     "change the parameters used to evaluate the difference between the\n",
-    "distributions: `p_age_threshold` and `p_sex_threshold`.\n",
+    "distributions: `p_val_threshold` and `t_val_threshold`.\n",
     "\n",
     "<div class=\"alert alert-block alert-info\">\n",
     "<b>Unique test set:</b>\n",
@@ -720,7 +724,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5b45893c",
+   "id": "86bd1e74",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -754,7 +758,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2bb51a9e",
+   "id": "471dee94",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -764,7 +768,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9500cd52",
+   "id": "3bfdbc9d",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -776,7 +780,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1d385b60",
+   "id": "563d7b44",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -805,7 +809,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6c98b0d6",
+   "id": "85b7deae",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -895,7 +899,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4f658289",
+   "id": "6eac69d7",
    "metadata": {},
    "source": [
     "If no Error was raised then none of the three conditions was broken. It is now\n",
@@ -916,7 +920,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d3e3a434",
+   "id": "6ac02602",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -928,7 +932,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bf610483",
+   "id": "15bc93b1",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/notebooks/preprocessing.ipynb
+++ b/notebooks/preprocessing.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cbd2a4b1",
+   "id": "49276cdd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "890001c8",
+   "id": "78e5538f",
    "metadata": {},
    "source": [
     "# Prepare your neuroimaging data\n",
@@ -29,7 +29,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0c1c8f25",
+   "id": "ef542410",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -74,7 +74,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "224dc7d5",
+   "id": "618da17f",
    "metadata": {},
    "source": [
     "\n",
@@ -104,18 +104,18 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7eb6b13d",
+   "id": "75727927",
    "metadata": {},
    "source": [
     "### Before starting\n",
     "We are going to run some experiments on the ADNI and OASIS datasets,\n",
-    "if you have already downloaded the full dataset, you can set the\n",
+    "if you have already download the full dataset, you can set the \n",
     "path to your own directory when needed."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "fd956b0e",
+   "id": "a15b35f4",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -128,7 +128,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52a3ac3a",
+   "id": "0912bd01",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -140,7 +140,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9ebefab5",
+   "id": "47d19963",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -150,7 +150,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17961f08",
+   "id": "63384fc8",
    "metadata": {},
    "source": [
     "\n",
@@ -162,7 +162,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4120640e",
+   "id": "5b806a52",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -175,7 +175,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bf20bb19",
+   "id": "2ddba112",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -187,7 +187,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e2b7bcb0",
+   "id": "1842fdd3",
    "metadata": {},
    "source": [
     "# Why prepare data ?\n",
@@ -217,7 +217,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7b68c832",
+   "id": "fb642ff9",
    "metadata": {},
    "source": [
     "\n",
@@ -243,7 +243,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2b71cac7",
+   "id": "d67ce14d",
    "metadata": {},
    "source": [
     "This notebook presents three possible preprocessing steps using the [Clinica](https://www.clinica.run/doc/)\n",
@@ -256,7 +256,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a28c624c",
+   "id": "28e3203e",
    "metadata": {},
    "source": [
     "<a id='preprocessing:t1-linear'></a>\n",
@@ -285,7 +285,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a044186a",
+   "id": "1cfd23ba",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -296,7 +296,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "94ad43a8",
+   "id": "e340ad26",
    "metadata": {},
    "source": [
     "These steps can be run with this simple command line:\n",
@@ -313,12 +313,12 @@
   },
   {
    "cell_type": "markdown",
-   "id": "df72c3d6",
+   "id": "35065f00",
    "metadata": {
     "lines_to_next_cell": 0
    },
    "source": [
-    "```{note}\n",
+    "```{info}\n",
     "The following command can take some time to execute, depending on the\n",
     "configuration of your host machine. Running in a classical **Colab** instance\n",
     "can take up to 30 min.\n",
@@ -331,7 +331,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "773c692b",
+   "id": "f8d708c5",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -342,7 +342,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fa9c521a",
+   "id": "16d5ecd9",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -353,7 +353,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ec25338f",
+   "id": "589edce0",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -365,7 +365,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f747c4bb",
+   "id": "852d46eb",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -377,7 +377,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50ab90a3",
+   "id": "e7419d53",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -389,7 +389,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "76d040f2",
+   "id": "005c147c",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -405,7 +405,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "580570f7",
+   "id": "f15ed70d",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -417,13 +417,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "176e22ac",
+   "id": "af3c4760",
    "metadata": {},
    "outputs": [],
    "source": [
     "from nilearn import plotting\n",
     "\n",
-    "suffix_caps = '_space-MNI152NLin2009cSym_desc-Crop_res-1x1x1_T1w.nii.gz'\n",
+    "suffix_caps = '_T1w_space-MNI152NLin2009cSym_desc-Crop_res-1x1x1_T1w.nii.gz'\n",
     "suffix_bids = '_T1w.nii.gz'\n",
     "sub1 = 'data_oasis/BIDS_example/sub-OASIS10016/ses-M000/anat/sub-OASIS10016_ses-M000' + suffix_bids \n",
     "sub2 = 'data_oasis/CAPS_example/subjects/sub-OASIS10016/ses-M000/t1_linear/sub-OASIS10016_ses-M000' + suffix_caps\n",
@@ -442,7 +442,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e4e06900",
+   "id": "5821f207",
    "metadata": {},
    "source": [
     "<a id='preprocessing:pet-linear'></a>\n",
@@ -462,17 +462,17 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fe9a5d15",
+   "id": "3893a7d9",
    "metadata": {},
    "source": [
-    "```{note}\n",
+    "```{info}\n",
     "You need to have performed the t1-linear pipeline on your T1-weighted MR images.\n",
     "```"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "aaf9a17a",
+   "id": "ec93330d",
    "metadata": {},
    "source": [
     "The pipeline can be run with the following command line:\n",
@@ -500,7 +500,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29946a5a",
+   "id": "b8c1d2dc",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -518,7 +518,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6b75ad0c",
+   "id": "efd3421f",
    "metadata": {},
    "source": [
     "### Run the pipeline\n",
@@ -535,7 +535,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "83100a49",
+   "id": "0e30c3b5",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -548,19 +548,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27d70de0",
+   "id": "d154e17c",
    "metadata": {
     "lines_to_next_cell": 0
    },
    "outputs": [],
    "source": [
     "!clinica run t1-linear data_adni/BIDS_example data_adni/CAPS_example --n_procs 2\n",
-    "!clinica run pet-linear data_adni/BIDS_example data_adni/CAPS_example 18FFDG cerebellumPons2 --n_procs 2"
+    "!clinica run pet-linear data_adni/BIDS_example data_adni/CAPS_example fdg cerebellumPons2 --n_procs 2"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "dd234e58",
+   "id": "c0ac81e5",
    "metadata": {},
    "source": [
     "Once the pipeline has been run, the necessary outputs for the next steps are\n",
@@ -570,7 +570,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cbf3de05",
+   "id": "42dcaecf",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -582,7 +582,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26249c38",
+   "id": "a6143f40",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -594,7 +594,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8fa32d19",
+   "id": "36dc194b",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -606,18 +606,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f8b42f8a",
+   "id": "6b242825",
    "metadata": {},
    "outputs": [],
    "source": [
     "from nilearn import plotting\n",
     "\n",
-    "suffix_caps = \"_task-rest_trc-18FFDG_space-MNI152NLin2009cSym_desc-Crop_res-1x1x1_suvr-cerebellumPons2_pet.nii.gz\"\n",
-    "suffix_bids = \"_task-rest_trc-18FFDG_pet.nii.gz\"\n",
-    "sub1 = f\"data_adni/BIDS_example/sub-ADNI005S0610/ses-M072/pet/sub-ADNI005S0610_ses-M072{suffix_bids}\"\n",
-    "sub2 = f\"data_adni/CAPS_example/subjects/sub-ADNI005S0610/ses-M072/pet_linear/sub-ADNI005S0610_ses-M072{suffix_caps}\"\n",
-    "sub3 = f\"data_adni/BIDS_example/sub-ADNI005S0929/ses-M000/pet/sub-ADNI005S0929_ses-M000{suffix_bids}\"\n",
-    "sub4 = f\"data_adni/CAPS_example/subjects/sub-ADNI005S0929/ses-M000/pet_linear/sub-ADNI005S0929_ses-M000{suffix_caps}\"\n",
+    "suffix_caps = '_task-rest_trc-fdg_pet_space-MNI152NLin2009cSym_desc-Crop_res-1x1x1_suvr-cerebellumPons2_pet.nii.gz'\n",
+    "suffix_bids = '_task-rest_trc-fdg_pet.nii.gz'\n",
+    "sub1 = 'data_adni/BIDS_example/sub-ADNI005S0610/ses-M72/pet/sub-ADNI005S0610_ses-M72' + suffix_bids \n",
+    "sub2 = 'data_adni/CAPS_example/subjects/sub-ADNI005S0610/ses-M72/pet_linear/sub-ADNI005S0610_ses-M72' + suffix_caps\n",
+    "\n",
+    "sub3 = 'data_adni/BIDS_example/sub-ADNI005S0929/ses-M00/pet/sub-ADNI005S0929_ses-M00' + suffix_bids\n",
+    "sub4 = 'data_adni/CAPS_example/subjects/sub-ADNI005S0929/ses-M00/pet_linear/sub-ADNI005S0929_ses-M00' + suffix_caps\n",
     "\n",
     "plotting.plot_anat(sub3, title=\"raw data: sub-ADNI005S0929\")\n",
     "plotting.plot_anat(sub4, title=\"preprocessed data: sub-ADNI005S0929\")\n",
@@ -630,7 +631,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2eda2463",
+   "id": "99c06794",
    "metadata": {},
    "source": [
     "# Quality check of your preprocessed data"
@@ -638,7 +639,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a5705b68",
+   "id": "59e3dbff",
    "metadata": {},
    "source": [
     "From the 2 visualizations above, we can see that after the preprocessing, some\n",
@@ -648,17 +649,17 @@
     "to evaluate the quality of the registration.\n",
     "\n",
     "OASIS-1 dataset contains 416 images  and ADNI more than 3000, so the quality \n",
-    "check of the entire datasets can be very time-consuming. The next section gives\n",
+    "check of the entire datasets can be very time consuming. The next section gives\n",
     "you some ideas on how to keep only the images correctly preprocessed when \n",
     "working on a large dataset."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "8730a00e",
+   "id": "9d28f397",
    "metadata": {},
    "source": [
-    "To automatically assess the quality of the **t1-linear** or the **pet-linear** preprocessing, we\n",
+    "To automatically assess the quality of the **t1-linear** preprocessing, we\n",
     "propose to use a pretrained network which learnt to classify images that are\n",
     "adequately registered to a template from others for which the registration\n",
     "failed. This procedure is adapted from [(Fonov et al,\n",
@@ -666,6 +667,9 @@
     "pretrained models. The original code of [(Fonov et al,\n",
     "2022)](https://doi.org/10.1016/j.neuroimage.2022.119266) can be found on\n",
     "[GitHub](https://github.com/vfonov/DARQ).\n",
+    "\n",
+    "The **pet-linear** quality check will be available soon in a next release of\n",
+    "ClinicaDL !\n",
     "\n",
     "The quality check can be run with the following command line:\n",
     "```\n",
@@ -681,16 +685,16 @@
     "`t1-volume`) containing QC results.\n",
     "\n",
     "#\n",
-    "```{note}\n",
+    ":::{note}\n",
     "Quality checks pipelines are all different and depend on the chosen\n",
     "preprocessing. They should not be applied to other preprocessing procedures as\n",
     "the results may not be reliable.\n",
-    "```"
+    ":::"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "05573890",
+   "id": "0b876404",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -701,7 +705,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9258886f",
+   "id": "6658accb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -712,17 +716,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f3cf03e5",
+   "id": "952712c6",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# quality-check for pet-linear preprocessing\n",
-    "!clinicadl quality-check pet-linear data_adni/CAPS_example data_adni/QC_result_pet.tsv 18FFDG cerebellumPons2"
+    "# quality-check for pet-linear preprocessing (coming soon)\n",
+    "!clinicadl quality-check pet-linear data_adni/CAPS_example data_adni/QC_result_pet.tsv fdg cerebellumPons2 --no-gpu"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "8b7ce2df",
+   "id": "9ad4d88d",
    "metadata": {},
    "source": [
     "```{warning}\n",
@@ -735,7 +739,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34ce0209",
+   "id": "0473cf99",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -746,7 +750,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33475484",
+   "id": "bf472d02",
    "metadata": {},
    "source": [
     "Based on these TSV file, participant `OASIS10304` should be discarded for the\n",
@@ -759,18 +763,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e155debf",
+   "id": "543d55aa",
    "metadata": {},
    "outputs": [],
    "source": [
     "# quality-check for pet-linear preprocessing \n",
-    "df_pet = pd.read_csv(\"data_adni/QC_result_pet.tsv\", sep=\"\\t\")\n",
+    "df_pet = pd.read_csv(\"data_adni/QC_results_pet.tsv\", sep=\"\\t\")\n",
     "print(df_pet)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "935ed006",
+   "id": "4dee399b",
    "metadata": {
     "lines_to_next_cell": 2
    },

--- a/notebooks/preprocessing.ipynb
+++ b/notebooks/preprocessing.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "004464cc",
+   "id": "cbd2a4b1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7130218e",
+   "id": "890001c8",
    "metadata": {},
    "source": [
     "# Prepare your neuroimaging data\n",
@@ -29,7 +29,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5b195725",
+   "id": "0c1c8f25",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -74,7 +74,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4d59c405",
+   "id": "224dc7d5",
    "metadata": {},
    "source": [
     "\n",
@@ -104,7 +104,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7f44ddfd",
+   "id": "7eb6b13d",
    "metadata": {},
    "source": [
     "### Before starting\n",
@@ -115,7 +115,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b6447ee3",
+   "id": "fd956b0e",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -128,7 +128,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "69a957cd",
+   "id": "52a3ac3a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -140,7 +140,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0d6f48f8",
+   "id": "9ebefab5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -150,7 +150,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "010b0cbf",
+   "id": "17961f08",
    "metadata": {},
    "source": [
     "\n",
@@ -162,7 +162,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2fad69e9",
+   "id": "4120640e",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -175,7 +175,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65d3dcfb",
+   "id": "bf20bb19",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -187,7 +187,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d9e9021c",
+   "id": "e2b7bcb0",
    "metadata": {},
    "source": [
     "# Why prepare data ?\n",
@@ -217,7 +217,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36daf2cc",
+   "id": "7b68c832",
    "metadata": {},
    "source": [
     "\n",
@@ -243,7 +243,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22dbf021",
+   "id": "2b71cac7",
    "metadata": {},
    "source": [
     "This notebook presents three possible preprocessing steps using the [Clinica](https://www.clinica.run/doc/)\n",
@@ -256,7 +256,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ba0fec5f",
+   "id": "a28c624c",
    "metadata": {},
    "source": [
     "<a id='preprocessing:t1-linear'></a>\n",
@@ -285,7 +285,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bcd5d880",
+   "id": "a044186a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -296,7 +296,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "536f0553",
+   "id": "94ad43a8",
    "metadata": {},
    "source": [
     "These steps can be run with this simple command line:\n",
@@ -313,7 +313,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b2cdbbd4",
+   "id": "df72c3d6",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -331,7 +331,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b1e33c9e",
+   "id": "773c692b",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -342,7 +342,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27cf5ee5",
+   "id": "fa9c521a",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -353,7 +353,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6d77de3e",
+   "id": "ec25338f",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -365,7 +365,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e74cea6a",
+   "id": "f747c4bb",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -377,7 +377,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c67b4d4a",
+   "id": "50ab90a3",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -389,7 +389,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e07faeab",
+   "id": "76d040f2",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -405,7 +405,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6ccd5924",
+   "id": "580570f7",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -417,7 +417,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e23cefac",
+   "id": "176e22ac",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -442,7 +442,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25a8d958",
+   "id": "e4e06900",
    "metadata": {},
    "source": [
     "<a id='preprocessing:pet-linear'></a>\n",
@@ -462,7 +462,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ce83b30b",
+   "id": "fe9a5d15",
    "metadata": {},
    "source": [
     "```{note}\n",
@@ -472,7 +472,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "64b80a63",
+   "id": "aaf9a17a",
    "metadata": {},
    "source": [
     "The pipeline can be run with the following command line:\n",
@@ -500,7 +500,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8d04dae2",
+   "id": "29946a5a",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -518,7 +518,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "911c3821",
+   "id": "6b75ad0c",
    "metadata": {},
    "source": [
     "### Run the pipeline\n",
@@ -535,7 +535,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ddc65bd6",
+   "id": "83100a49",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -548,7 +548,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e095edc8",
+   "id": "27d70de0",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -560,7 +560,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "174b374b",
+   "id": "dd234e58",
    "metadata": {},
    "source": [
     "Once the pipeline has been run, the necessary outputs for the next steps are\n",
@@ -570,7 +570,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a9cd4de9",
+   "id": "cbf3de05",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -582,7 +582,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "939f91d5",
+   "id": "26249c38",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -594,7 +594,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31fca7e7",
+   "id": "8fa32d19",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -606,7 +606,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "80c0d920",
+   "id": "f8b42f8a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -630,7 +630,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9b6cd553",
+   "id": "2eda2463",
    "metadata": {},
    "source": [
     "# Quality check of your preprocessed data"
@@ -638,7 +638,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f0e88e80",
+   "id": "a5705b68",
    "metadata": {},
    "source": [
     "From the 2 visualizations above, we can see that after the preprocessing, some\n",
@@ -655,7 +655,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f2672e7a",
+   "id": "8730a00e",
    "metadata": {},
    "source": [
     "To automatically assess the quality of the **t1-linear** or the **pet-linear** preprocessing, we\n",
@@ -690,7 +690,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0d484d24",
+   "id": "05573890",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -701,7 +701,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "350736c6",
+   "id": "9258886f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -712,7 +712,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "887d262a",
+   "id": "f3cf03e5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -722,7 +722,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "db5d122f",
+   "id": "8b7ce2df",
    "metadata": {},
    "source": [
     "```{warning}\n",
@@ -735,7 +735,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1dc6e061",
+   "id": "34ce0209",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -746,7 +746,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b6cb198f",
+   "id": "33475484",
    "metadata": {},
    "source": [
     "Based on these TSV file, participant `OASIS10304` should be discarded for the\n",
@@ -759,7 +759,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "395bc442",
+   "id": "e155debf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -770,7 +770,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3060e4f4",
+   "id": "935ed006",
    "metadata": {
     "lines_to_next_cell": 2
    },

--- a/src/label_extraction.py
+++ b/src/label_extraction.py
@@ -124,7 +124,7 @@
 # download the full data from [ADNI](https://adni.loni.usc.edu/) or
 # [OASIS](https://oasis-brains.org/). Indeed, it is not possible to separate a
 # set of 4 images without data leakage. You will need also to process the data,
-# as shown in the [previous notebook]((./preprocessing.ipynb)), in a BIDS and a
+# as shown in the [previous notebook](./preprocessing.ipynb), in a BIDS and a
 # CAPS specification.
 #```
 #
@@ -196,8 +196,8 @@
 # <b>Restriction path:</b><p>
 #     At the end of the command line a restriction was given to extract the
 #     labels only from sessions in <code>data/oasis_after_qc.tsv</code>. This tsv
-#     file corresponds to the output of the <a
-#     href="./preprocessing.ipynb">quality check procedure</a> that was manually
+#     file corresponds to the output of the 
+#     [quality check procedure](./preprocessing.ipynb) that was manually
 #     cut to only keep the sessions passing the quality check. It depends on the
 #     preprocessing: here it concerns a run of <code>t1-linear</code>.</p>
 # </div>
@@ -218,8 +218,8 @@
 # clinicadl tsvtools analysis <merged_tsv> <data_tsv> <results_path>
 # ```
 # where:
-# - `merged_tsv` is the output file of the `clinica iotools merge-tsv`command.
-# - `data_tsv` is the output file of `clinicadl tsvtool getlabels|split|kfold`).
+# - `merged_tsv` is the output file of the `clinica iotools merge-tsv` command.
+# - `data_tsv` is the output file of `clinicadl tsvtool getlabels|split|kfold`.
 # - `results_path` is the path to the tsv file that will be written (filename included).
 
 
@@ -309,7 +309,7 @@ display_table("data_adni/analysis.tsv")
 #   clinicadl tsvtools get-progression [OPTIONS] DATA_TSV
 # ``` 
 # with :
-#  - `<data_tsv>` (str) is the TSV file containing the data (output of clinicadl
+#  - `DATA_TSV` (str) is the TSV file containing the data (output of clinicadl
 #  tsvtools get-labels|split|kfold).
 #  - `--time_horizon` (int) can be added: It is the time horizon in months that
 #  is used to assess the stability of the MCI subjects. Default value: 36.

--- a/src/label_extraction.py
+++ b/src/label_extraction.py
@@ -403,7 +403,7 @@ display_table("data_oasis/analysis_trainval.tsv")
 print("Test set")
 display_table("data_oasis/analysis_test.tsv")
 # %% [markdown]
-# If you are not satisfied with these populations, you can relaunch the `clinicadl tsvtools split` or
+# If you are not satisfied with these populations, you can relaunch the `clinicadl tsvtools split` command and
 # change the parameters used to evaluate the difference between the
 # distributions: `p_age_threshold` and `p_sex_threshold`.
 

--- a/src/label_extraction.py
+++ b/src/label_extraction.py
@@ -403,9 +403,9 @@ display_table("data_oasis/analysis_trainval.tsv")
 print("Test set")
 display_table("data_oasis/analysis_test.tsv")
 # %% [markdown]
-# If you are not satisfied with these populations, you can relaunch the test or
+# If you are not satisfied with these populations, you can relaunch the `clinicadl tsvtools split` or
 # change the parameters used to evaluate the difference between the
-# distributions: `p_val_threshold` and `t_val_threshold`.
+# distributions: `p_age_threshold` and `p_sex_threshold`.
 
 # <div class="alert alert-block alert-info">
 # <b>Unique test set:</b>

--- a/src/label_extraction.py
+++ b/src/label_extraction.py
@@ -124,7 +124,7 @@
 # of the sessions, for now. 
 #
 # The whole preprocessing process has been run for you on these datasets. The
-# results of the [quality check procedure](./preprocessing.ipynb) have been used
+# results of the [quality check procedure](./preprocessing.ipynb#quality-check-of-your-preprocessed-data) have been used
 # to filter sessions. `data_oasis/oasis_after_qc.tsv` and `data_adni/adni_after_qc.tsv`
 # store the list of the sessions that have been accepted for each dataset.
 # 
@@ -192,8 +192,8 @@
 # <b>Restriction path:</b><p>
 #     At the end of the command line, a restriction was given to extract the
 #     labels only from sessions in <code>oasis_after_qc.tsv</code>. This tsv
-#     file corresponds to the output of the 
-#     [quality check procedure](./preprocessing.ipynb) that was manually
+#     file corresponds to the output of the  <a
+#     href="./preprocessing.html#quality-check-of-your-preprocessed-data">quality check procedure</a> that was manually
 #     cut to only keep the sessions passing the quality check. It depends on the
 #     preprocessing: here it concerns a run of <code>t1-linear</code>.</p>
 # </div>

--- a/src/label_extraction.py
+++ b/src/label_extraction.py
@@ -177,7 +177,7 @@
 # to the only available labels in OASIS. Run the following cell to extract them
 # in a new file `labels.tsv` from the restricted version of OASIS:
 # %%
-!clinicadl tsvtools get-labels data_oasis/BIDS_example --merged_tsv data_oasis/merged.tsv --missing_mods data_oasis/missing_mods --restriction_tsv data/oasis_after_qc.tsv
+!clinicadl tsvtools get-labels data_oasis/BIDS_example data_oasis --merged_tsv data_oasis/merged.tsv --missing_mods data_oasis/missing_mods --restriction_tsv data_oasis/oasis_after_qc.tsv
 # %% [markdown]
 
 # In the ADNI dataset, a subject can have several sessions during his follow-up 
@@ -187,7 +187,7 @@
 # disease as 'AD' but as 'Dementia' so you need to add the `--diagnosis`/`-d` 
 # option.
 # %%
-!clinicadl tsvtools get-labels data_adni/BIDS_example --merged_tsv data_adni/merged.tsv --missing_mods data_adni/missing_mods --restriction_tsv data/adni_after_qc.tsv -d CN -d Dementia -d MCI
+!clinicadl tsvtools get-labels data_adni/BIDS_example data_adni --merged_tsv data_adni/merged.tsv --missing_mods data_adni/missing_mods --restriction_tsv data_adni/adni_after_qc.tsv -d CN -d Dementia -d MCI
 # %% [markdown]
 # This tool writes a unique TSV file containing the labels asked by the user.
 # They are stored in the column named diagnosis.

--- a/src/label_extraction.py
+++ b/src/label_extraction.py
@@ -119,34 +119,30 @@
 # %% [markdown]
 # ## Prepare metadata with `clinicadl tsvtools` 
 
-# ```{note}
-# If you want to do the next experiment in proper conditions, you will have to
-# download the full data from [ADNI](https://adni.loni.usc.edu/) or
-# [OASIS](https://oasis-brains.org/). Indeed, it is not possible to separate a
-# set of 4 images without data leakage. You will need also to process the data,
-# as shown in the [previous notebook](./preprocessing.ipynb), in a BIDS and a
-# CAPS specification.
-#```
+# In this section we will work on a subset of 100 sessions of the OASIS dataset
+# (and a subset of 100 sessions of the ADNI dataset) and you only need the list
+# of the sessions, for now. 
 #
-# In this section we will work on a subset of 100 subjects of the OASIS dataset
-# (and a subset of 100 subjects of the ADNI dataset) and you only need the list
-# of subjects, for now. You can find this list of participants that have passed
-# the quality check in the data folder (`oasis_after_qc.tsv` and 
-# `adni_after_qc.tsv`).
-#
-# If you are not able to run the whole preprocessing process on the full
-# dataset, you can uncomment the next cell and download the necessary resources
-# (the `merged.tsv` file  and the `missing_mods` directory).
+# The whole preprocessing process has been run for you on these datasets. The
+# results of the [quality check procedure](./preprocessing.ipynb) have been used
+# to filter sessions. `data_oasis/oasis_after_qc.tsv` and `data_adni/adni_after_qc.tsv`
+# store the list of the sessions that have been accepted for each dataset.
+# 
+# You can run the next cell to download the necessary resources
+# (`merged.tsv` and `oasis_after_qc.tsv` - or `adni_after_qc.tsv` - files,
+# as well as the `missing_mods` directory).
 
 # %%
 #for OASIS-1 dataset
 !curl -k https://aramislab.paris.inria.fr/clinicadl/files/handbook_2023/data_oasis/iotools_output.tar.gz -o iotools_output.tar.gz
 !tar xf iotools_output.tar.gz
+!curl https://raw.githubusercontent.com/aramis-lab/clinicadl_handbook/main/data/oasis_after_qc.tsv  -O data_oasis/oasis_after_qc.tsv
 
 # %%
 #for the ADNI dataset
 !curl -k https://aramislab.paris.inria.fr/clinicadl/files/handbook_2023/data_adni/iotools_output.tar.gz -o iotools_output.tar.gz
 !tar xf iotools_output.tar.gz
+!curl https://raw.githubusercontent.com/aramis-lab/clinicadl_handbook/main/data/adni_after_qc.tsv  -O data_adni/adni_after_qc.tsv
 
 # %% [markdown]
 # ### Get the labels
@@ -194,8 +190,8 @@
 
 # <div class="alert alert-block alert-info">
 # <b>Restriction path:</b><p>
-#     At the end of the command line a restriction was given to extract the
-#     labels only from sessions in <code>data/oasis_after_qc.tsv</code>. This tsv
+#     At the end of the command line, a restriction was given to extract the
+#     labels only from sessions in <code>oasis_after_qc.tsv</code>. This tsv
 #     file corresponds to the output of the 
 #     [quality check procedure](./preprocessing.ipynb) that was manually
 #     cut to only keep the sessions passing the quality check. It depends on the


### PR DESCRIPTION
Fixes #27. Mainly focuses on the `get-labels` section to make it clearer. 

Sorry, the PR is polluted with a lot of changes in the ids of the cells of the notebooks (if you know how to build the notebooks without changing the ids, I would be happy to know that). Go directly to .py files to see the actual changes.